### PR TITLE
URL-decode DB user/password to allow special chars

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -44,10 +44,17 @@ query_wait_timeout = ${PGBOUNCER_QUERY_WAIT_TIMEOUT:-120}
 [databases]
 EOFEOF
 
+function urldecode() {
+  echo "$1" | sed -e 's@+@ @g;s@%@\\x@g' | xargs -0 printf "%b"
+}
+
 for POSTGRES_URL in $POSTGRES_URLS
 do
   eval POSTGRES_URL_VALUE=\$$POSTGRES_URL
   IFS=':' read DB_USER DB_PASS DB_HOST DB_PORT DB_NAME <<< $(echo $POSTGRES_URL_VALUE | perl -lne 'print "$1:$2:$3:$4:$5" if /^postgres(?:ql)?:\/\/([^:]*):([^@]*)@(.*?):(.*?)\/(.*?)$/')
+
+  DB_USER="$(urldecode "$DB_USER")"
+  DB_PASS="$(urldecode "$DB_PASS")"
 
   DB_MD5_PASS="md5"`echo -n ${DB_PASS}${DB_USER} | md5sum | awk '{print $1}'`
 


### PR DESCRIPTION
Hello,

We have learned the hard way that unfortunately this buildpack doesn't support special characters (specifically `@`) in usernames and passwords. These characters should be URL-encoded - see e.g. how Django package that adds support for `DATABASE_URL` handles it:

https://github.com/jacobian/dj-database-url/blob/master/dj_database_url.py#L124

However, the buildpack doesn't decode them and therefore uses wrong passwords for user list and database.

This commit adds decoding to the buildpack and thus fixes the issue /cc @marns93 .

All the best,
Yury

